### PR TITLE
[SVLS-7126] volume size_limit and sidecar startup_probe customizability added

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ locals {
     ] : coalesce(var.template.volumes, [])
  
  # flag if logging is enabled and shared_volume is already in the template volumes (name of volume exists)
-  shared_volume_already_exists = length(var.template.volumes) != length(local.volumes_without_shared_volume)
+  shared_volume_already_exists = length(coalesce(var.template.volumes, []) ) != length(local.volumes_without_shared_volume)
 
   # User-check 2: check if sidecar container already exists and remove it from the var.template.containers list if it does (to be overridden by module's instantiation)
   containers_without_sidecar = [


### PR DESCRIPTION
- volume will remain fixed at `empty_dir`, `MEMORY` settings, but `size_limit` is an optional setting users can configure
- startup probe for the sidecar has a default of the following, in accordance with other instrumentation versions and only allows user input on `failure_threshold`, `period_seconds`, `initial_delay_seconds`, `timeout_seconds` (only tcp socket connection will be supported), port set through the `var.datadog_sidecar.health_port`
```
{ # default startup probe
    failure_threshold = 3
    period_seconds = 10
    initial_delay_seconds = 0
    timeout_seconds = 1
    tcp_socket = {
      port = 5555
    }
}
```