### PR TITLE
[SVLS-7127] Pinning provider and resource versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.45.0"
+      version = ">= 6.34.0"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->
Found and pinned lowest google provider version module supports, reflected in all examples' readme and versions and terraform docs generations.
### Motivation
<!--
What inspired you to submit this pull request?
-->

- We should only require the minimum version for maximum user flexibility

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->
`terraform init -upgrade && terraform validate` and trying different provider versions until reached the lowest one that still compiles properly with this command.
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->