### PR TITLE
[SVLS] support secret ref env vars

### DIFF
--- a/smoke_tests/environment_variable_tests/main_container_env_vars.tf
+++ b/smoke_tests/environment_variable_tests/main_container_env_vars.tf
@@ -164,6 +164,42 @@ module "container-level-override" {
 }
 
 
+module "value-source-preserved" {
+  source = "../.."
+
+  name     = "test-secret-manager"
+  project  = "test-project"
+  location = "us-central1"
+
+  datadog_api_key = "test-api-key"
+
+  template = {
+    containers = [
+      {
+        name  = "main"
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+
+        env = [
+          {
+            name  = "PLAIN_ENV_VAR"
+            value = "plain-value"
+          },
+          {
+            name = "SECRET_ENV_VAR"
+            value_source = {
+              secret_key_ref = {
+                secret  = "projects/test-project/secrets/my-secret"
+                version = "latest"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+
+
 resource "google_cloud_run_service_iam_member" "invoker_dd_main_module_level_override" {
   service  = module.module-level-override.name
   location = module.module-level-override.location


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

Implementation for this PR https://github.com/DataDog/terraform-google-cloud-run-datadog/pull/25

> Modified the environment variable merge logic in main.tf to:
> 
> Preserve environment variables that have value_source defined (Secret Manager references)
> Only convert environment variables without value_source to the merged format
> Ensure module-managed variables (DD_SERVICE, DD_VERSION, etc.) don't override user-defined secret references


### Motivation
<!--
What inspired you to submit this pull request?
-->

https://github.com/DataDog/terraform-google-cloud-run-datadog/pull/25

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

Tested with the examples and validated the new smoke test works

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->
