### PR TITLE
[SVLS-7675] Add a module version label to the service

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
 locals {
+  module_version  = "1_0_2"
   datadog_service = var.datadog_service != null ? var.datadog_service : var.name
   datadog_logging_vol = { #the shared volume for logging which each container can write their Datadog logs to
     name = var.datadog_shared_volume.name
@@ -116,7 +117,7 @@ check "function_target_is_provided" {
 # Implementation
 locals {
   # Default service tag value to cloud run resource name if not provided
-  labels = merge({ service = local.datadog_service }, var.labels)
+  labels = merge({ service = local.datadog_service, dd_sls_terraform_module_cloud_run = local.module_version }, var.labels)
 
   # Update the environments on the containers
   template_containers = concat([local.sidecar_container],


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

This PR makes the module add a label to the cloud run service or function. The label is in the format `dd_sls_terraform_module_cloud_run:X_Y_Z` where X, Y, and Z are the major, minor, and patch versions of the module. They're separated by underscores because GCP doesn't allow periods in their labels, only lowercase letters, numeric values, dashes, and underscores.

### Motivation
<!--
What inspired you to submit this pull request?
-->

We don't have the ability to process these labels yet in the integration, but eventually having these labels could help us track module usage and break it down by version. We have usage tracking based on a similar label for the lambda terraform module.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->
Deployed one of the examples and saw that it had the label applied.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->
