### PR TITLE
[CHORE] fix terraform lint CI

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -26,4 +26,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Run TFLint
-        run: tflint --recursive --config "$(pwd)/.tflint.hcl"
+        run: |
+          tflint --recursive --config "$(pwd)/.tflint.hcl"
+          echo All files passed the linter!


### PR DESCRIPTION
### What does this PR do?
<!--
A brief description of the change being made with this pull request.
-->

fixes for:
```
The action terraform-linters/setup-tflint@acd1575d3c037258ce5b2dd01379dc49ce24c6b7 is not allowed in DataDog/terraform-azurerm-web-app-datadog because all actions must be from a repository owned by your enterprise, created by GitHub, or verified in the GitHub Marketplace.
```

### Motivation
<!--
What inspired you to submit this pull request?
-->

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* The PR description contains details of how you validated your changes.
-->

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Possible drawbacks and tradeoffs.
* Include info about alternatives that were considered and why the proposed version was chosen.
-->
