### PR TITLE
Add uk1.datadoghq.com as a supported Datadog site

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -23,9 +23,10 @@ variable "datadog_site" {
         "us2.ddog-gov.com",
         "ap1.datadoghq.com",
         "ap2.datadoghq.com",
+        "uk1.datadoghq.com",
       ],
     var.datadog_site)
-    error_message = "Invalid Datadog site. Valid options are: 'datadoghq.com', 'datadoghq.eu', 'us5.datadoghq.com', 'us3.datadoghq.com', 'ddog-gov.com', 'us2.ddog-gov.com', 'ap1.datadoghq.com', or 'ap2.datadoghq.com'."
+    error_message = "Invalid Datadog site. Valid options are: 'datadoghq.com', 'datadoghq.eu', 'us5.datadoghq.com', 'us3.datadoghq.com', 'ddog-gov.com', 'us2.ddog-gov.com', 'ap1.datadoghq.com', 'ap2.datadoghq.com', or 'uk1.datadoghq.com'."
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

Add \`uk1.datadoghq.com\` to the \`datadog_site\` validation list in \`variables.tf\`.

### Motivation

New Datadog datacenter support.

### Describe how you validated your changes

Updated the validation list and error message in \`variables.tf\`.

### Additional Notes

N/A